### PR TITLE
fix date_parsed for new feedparser

### DIFF
--- a/newswall/providers/feed.py
+++ b/newswall/providers/feed.py
@@ -21,8 +21,15 @@ class Provider(ProviderBase):
         feed = feedparser.parse(self.config['source'])
 
         for entry in feed['entries']:
+            if hasattr(entry, 'date_parsed'):
+                timestamp = datetime.fromtimestamp(time.mktime(entry.date_parsed))
+            elif hasattr(entry, 'published_parsed'):
+                timestamp = datetime.fromtimestamp(time.mktime(entry.published_parsed))
+            else:
+                timestamp = datetime.now()
+
             self.create_story(entry.link,
                 title=entry.title,
                 body=entry.description,
-                timestamp=datetime.fromtimestamp(time.mktime(entry.date_parsed)),
+                timestamp=timestamp,
                 )

--- a/newswall/providers/twitter.py
+++ b/newswall/providers/twitter.py
@@ -21,7 +21,14 @@ class Provider(ProviderBase):
         feed = feedparser.parse("http://twitter.com/statuses/user_timeline/%s.rss?count=100" % self.config['user'])
 
         for entry in feed['entries']:
+            if hasattr(entry, 'date_parsed'):
+                timestamp = datetime.fromtimestamp(time.mktime(entry.date_parsed))
+            elif hasattr(entry, 'published_parsed'):
+                timestamp = datetime.fromtimestamp(time.mktime(entry.published_parsed))
+            else:
+                timestamp = datetime.now()
+
             self.create_story(entry.link,
                 title=entry.title,
-                timestamp=datetime.fromtimestamp(time.mktime(entry.date_parsed)),
+                timestamp=timestamp,
                 )


### PR DESCRIPTION
it seems, that the new feedparser (v5.1.1) doesn`t propagate "date_parsed" for entries. "publised_parsed" is
the new kid on the block. Anyway, some feeds can come without any of these attributes, so we have
a fallback: datetime.now() for the timestamp. This fix is backwards compatible with older feedparser versions
