### PR TITLE
elephantblog dependency

### DIFF
--- a/newswall/feeds.py
+++ b/newswall/feeds.py
@@ -5,9 +5,9 @@ from newswall.models import Story
 
 
 class StoryFeed(Feed):
-    title = settings.BLOG_TITLE
+    title = getattr(settings, 'BLOG_TILE', 'Default Title')
     link = '/news/'
-    description = settings.BLOG_DESCRIPTION
+    description = getattr(settings, 'BLOG_DESCRIPTION', 'Default Description')
 
     def items(self):
         return Story.objects.active().order_by('-timestamp')[:20]


### PR DESCRIPTION
I don't know why story feed gets title and description from the elephantblog settings. should be a seperate settings in my opinion. 
