### PR TITLE
Add compatibility with Django 1.7+

### DIFF
--- a/newswall/management/commands/update_newswall.py
+++ b/newswall/management/commands/update_newswall.py
@@ -1,5 +1,11 @@
 from django.core.management.base import NoArgsCommand
-from django.utils import importlib, simplejson
+from django.utils import importlib
+
+try:
+    import json
+except ImportError:
+    # maintain compatibility with Django < 1.7
+    from djanto.utils import simplejson as json
 
 from newswall.models import Source
 
@@ -9,7 +15,7 @@ class Command(NoArgsCommand):
 
     def handle_noargs(self, **options):
         for source in Source.objects.filter(is_active=True):
-            config = simplejson.loads(source.data)
+            config = json.loads(source.data)
             provider = importlib.import_module(
                 config['provider']).Provider(source, config)
             provider.update()

--- a/newswall/providers/fb_graph_feed.py
+++ b/newswall/providers/fb_graph_feed.py
@@ -21,7 +21,11 @@ import urllib
 
 from datetime import datetime
 
-from django.utils import simplejson
+try:
+    from django.utils import json
+except ImportError:
+    # maintain compatibility with Django < 1.7
+    from django.utils import simplejson as json
 
 from newswall.providers.base import ProviderBase
 
@@ -35,7 +39,7 @@ class Provider(ProviderBase):
         )
         file = urllib.urlopen(query)
         raw = file.read()
-        response = simplejson.loads(raw)
+        response = json.loads(raw)
 
         from_id = self.config.get('from_id', None)
 


### PR DESCRIPTION
Use `json` instead of `django.utils.simplejson` in Django 1.7 and above.